### PR TITLE
Configure custom domain prateek-rajput.com

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+prateek-rajput.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Prateek Rajput"
 description: "Senior Data Engineer & Backend Engineering Leader"
-url: "https://prateek-217.github.io"
+url: "https://prateek-rajput.com"
 baseurl: ""
 
 author:


### PR DESCRIPTION
## Summary
- Configure Jekyll site to use custom domain `prateek-rajput.com`
- Update `_config.yml` with new URL
- Add CNAME file for GitHub Pages

## Changes Made
- ✅ Updated Jekyll configuration URL
- ✅ Added CNAME file pointing to custom domain
- ✅ Ready for deployment

## Next Steps
After merging this PR:
1. GitHub Pages will automatically recognize the custom domain
2. Site will be available at https://prateek-rajput.com
3. DNS propagation may take 5-60 minutes

## DNS Configuration
Already configured in Namecheap:
- A records pointing to GitHub Pages IPs
- CNAME record for www subdomain

🤖 Generated with [Claude Code](https://claude.ai/code)